### PR TITLE
Fix: Dragon-shield weight

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -1155,6 +1155,7 @@ struct obj	*sobj;
 					otmp->blessed = 1;
 				}
 				otmp->known = 1;
+				otmp->owt = weight(otmp);
 				setworn(otmp, W_ARMS);
 				break;
 			} else {


### PR DESCRIPTION
Recalculates the weight of dragon-scale shields when they are made in the usual method. They will now properly weigh 75 units, like they are listed in objects.c.
Previously, the shield would retain the body-armor scales' weight of 150 units for most (but not all) purposes.